### PR TITLE
Deduplication of data, Implement getting Likes (for Posts) and Posts (for Users)

### DIFF
--- a/backend/app/server/controllers/like.py
+++ b/backend/app/server/controllers/like.py
@@ -1,7 +1,5 @@
 from bson.objectid import ObjectId
 from ..database import likes_collection, users_collection
-from fastapi import HTTPException
-from .post import add_like_id, delete_like_id
 
 # helpers
 
@@ -24,33 +22,16 @@ async def initialize_like(user_id: ObjectId, post_id: ObjectId, like_details: di
 # Add a post id to the like model
 async def like_unlike_post(email: str, like_details: dict):
     user = await users_collection.find_one({"email": email})
-    raise_error = False
     entry_exists = await likes_collection.find_one({"post_id": ObjectId(like_details["post_id"]), "user_id": user["_id"]})
     if not entry_exists:
         # First Time: create entry
         like_details = await initialize_like(user["_id"], ObjectId(like_details["post_id"]), like_details)
         new_like = await likes_collection.insert_one(like_details)
         return_like = await likes_collection.find_one({"_id": new_like.inserted_id})
-
-        # Update Post like entry
-        if not await add_like_id(ObjectId(like_details["post_id"]), return_like["_id"]):
-            raise_error = True
     else:
         # Next Time: update the is_liked label
         await likes_collection.update_one(
             {"user_id": entry_exists["user_id"]}, {"$set": {"is_liked": not entry_exists["is_liked"]}}
         )
         return_like = await likes_collection.find_one({"post_id": ObjectId(like_details["post_id"]), "user_id": user["_id"]})
-
-        # Update Post like entry
-        if return_like["is_liked"] is True:
-            if not await add_like_id(ObjectId(like_details["post_id"]), return_like["_id"]):
-                raise_error = True
-        else:
-            if not await delete_like_id(ObjectId(like_details["post_id"]), return_like["_id"]):
-                raise_error = True
-
-    if raise_error:
-        raise HTTPException(501, detail='Something went wrong, try again.')
-    else:
-        return like_helper(return_like)
+    return like_helper(return_like)

--- a/backend/app/server/controllers/like.py
+++ b/backend/app/server/controllers/like.py
@@ -1,5 +1,6 @@
 from bson.objectid import ObjectId
 from ..database import likes_collection, users_collection
+from .user import retrieve_user
 
 # helpers
 
@@ -10,6 +11,14 @@ def like_helper(like) -> dict:
         "user_id": str(like["user_id"]),
         "is_liked": like["is_liked"]
     }
+
+
+async def get_all_likes_on_post(post_id: ObjectId):
+    likes = []
+    async for like in likes_collection.find({"post_id": post_id}, {"user_id", "is_liked"}):
+        if like["is_liked"] is True:
+            likes.append(await retrieve_user(like["user_id"], lightweight=True))
+    return likes
 
 
 async def initialize_like(user_id: ObjectId, post_id: ObjectId, like_details: dict) -> dict:

--- a/backend/app/server/controllers/user.py
+++ b/backend/app/server/controllers/user.py
@@ -6,7 +6,15 @@ from .auth import auth_handler
 # helpers
 
 
-def user_helper(user) -> dict:
+def user_helper(user, lightweight=False) -> dict:
+    if lightweight:
+        return {
+            "user_id": str(user["_id"]),
+            "name": user["name"],
+            "email": user["email"],
+            "profile_picture": user["profile_picture"]
+        }
+
     posts = [str(x) for x in user["posts"]]
     return {
         "user_id": str(user["_id"]),
@@ -47,10 +55,10 @@ async def login(user_data: dict) -> dict:
 
 
 # Retrieve a user with a matching ID
-async def retrieve_user(id: str) -> dict:
+async def retrieve_user(id: str, lightweight: bool = False) -> dict:
     user = await users_collection.find_one({"_id": ObjectId(id)})
     if user:
-        return user_helper(user)
+        return user_helper(user, lightweight=lightweight)
 
 
 # Update a user with a matching ID

--- a/backend/app/server/controllers/user.py
+++ b/backend/app/server/controllers/user.py
@@ -74,35 +74,3 @@ async def delete_user(email: str):
     if user:
         await users_collection.delete_one({"email": email})
         return True
-
-
-# Add a post id to the user model
-async def add_post_id(user_id: ObjectId, post_id: ObjectId):
-    already_exists = await users_collection.find_one(
-        {"_id": user_id, "posts": post_id}
-    )
-    if already_exists:
-        return False
-    else:
-        user = await users_collection.update_one(
-            {"_id": user_id}, {"$push": {"posts": post_id}}
-        )
-        if user:
-            return True
-        return False
-
-
-# Delete a post id from user model
-async def delete_post_id(user_id: ObjectId, post_id: ObjectId):
-    already_exists = await users_collection.find_one(
-        {"_id": user_id, "posts": post_id}
-    )
-    if already_exists:
-        user = await users_collection.update_one(
-            {"_id": user_id}, {"$pull": {"posts": post_id}}
-        )
-        if user:
-            return True
-        return False
-    else:
-        return False

--- a/backend/app/server/models/post.py
+++ b/backend/app/server/models/post.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, Field
 class PostSchema(BaseModel):
     user_id: str = Field(None)
     report_counter: int = Field(0, ge=0)
-    likes: list = Field([])
     image: str = Field(...)
     description: str = Field(None)
 

--- a/backend/app/server/models/user.py
+++ b/backend/app/server/models/user.py
@@ -8,7 +8,6 @@ class UserSchema(BaseModel):
     password: str = Field(...)
     profile_picture: str = Field(None)
     description: str = Field(None)
-    posts: list = Field([])
 
     class Config:
         schema_extra = {


### PR DESCRIPTION
After this fix, a simple response from `GET /user/details` would be:
```yaml
{
  "user_id": "606655860323ed241e902b4b",
  "name": "Aitik Gupta",
  "email": "a@b.c",
  "profile_picture": "url_of_image",
  "description": "This is Aitik",
  "posts": [
    {
      "post_id": "60665c091b7088aa65352c2b",
      "user_id": "606655860323ed241e902b4b",
      "author_name": "Aitik Gupta",
      "author_email": "a@b.c",
      "report_counter": 0,
      "likes_by_users": [
        {
          "user_id": "606655860323ed241e902b4b",
          "name": "Aitik Gupta",
          "email": "a@b.c",
          "profile_picture": "url_of_image"
        },
        {
          "user_id": "6066665e44d676daed4d3490",
          "name": "New User",
          "email": "c@d.f",
          "profile_picture": "url_of_image"
        }
      ],
      "image": "URL",
      "description": "This is a post by Aitik"
    }
  ]
}

```


This also implements a lightweight user helper, which can be used to display small photos and names of people who liked the post. Resolves #36