### PR TITLE
Implement Comments API for posts

### DIFF
--- a/backend/app/server/app.py
+++ b/backend/app/server/app.py
@@ -5,6 +5,7 @@ from .routes.users import router as UsersRouter
 from .routes.post import router as PostRouter
 from .routes.posts import router as PostsRouter
 from .routes.like import router as LikeRouter
+from .routes.comment import router as CommentRouter
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
@@ -24,6 +25,7 @@ app.include_router(UsersRouter, tags=["Users"], prefix="/users")
 app.include_router(PostRouter, tags=["Post"], prefix="/post")
 app.include_router(PostsRouter, tags=["Posts"], prefix="/posts")
 app.include_router(LikeRouter, tags=["Like/Unlike"], prefix="/like_unlike")
+app.include_router(CommentRouter, tags=["Comment"], prefix="/comment_uncomment")
 
 
 @app.get("/", tags=["Root"])

--- a/backend/app/server/controllers/comment.py
+++ b/backend/app/server/controllers/comment.py
@@ -1,0 +1,78 @@
+from bson.objectid import ObjectId
+from fastapi import HTTPException
+from ..database import comments_collection, users_collection
+
+# helpers
+
+
+# lightweight modes defined here due to circular dependencies
+# Only Likes and Comments APIs should return lightweight user details
+def user_helper_lightweight(user, comment_id, payload) -> dict:
+    return {
+        "comment_id": str(comment_id),
+        "user_id": str(user["_id"]),
+        "name": user["name"],
+        "email": user["email"],
+        "profile_picture": user["profile_picture"],
+        "payload": payload
+    }
+
+
+async def retrieve_user_lightweight(user_id: ObjectId, comment_id: ObjectId, comment_payload: str):
+    user = await users_collection.find_one({"_id": user_id})
+    if user:
+        return user_helper_lightweight(user, comment_id, comment_payload)
+
+
+def comment_helper(comment) -> dict:
+    return {
+        "post_id": str(comment["post_id"]),
+        "user_id": str(comment["user_id"]),
+        "payload": comment["payload"],
+        "is_commented": comment["is_commented"]
+    }
+
+
+async def get_all_comments_on_post(post_id: ObjectId):
+    comments = []
+    async for comment in comments_collection.find({"post_id": post_id}, {"user_id", "payload", "is_commented"}):
+        if comment["is_commented"] is True:
+            comments.append(await retrieve_user_lightweight(comment["user_id"], comment["_id"], comment["payload"]))
+    return comments
+
+
+async def initialize_comment(user_id: ObjectId, post_id: ObjectId, comment_details: dict) -> dict:
+    comment_details["user_id"] = user_id
+    comment_details["post_id"] = post_id
+    comment_details["is_commented"] = True
+    return comment_details
+
+
+# Add a post id to the comment model
+async def add_comment(email: str, comment_details: dict):
+    user = await users_collection.find_one({"email": email})
+    # create entry
+    comment_details = await initialize_comment(user["_id"], ObjectId(comment_details["post_id"]), comment_details)
+    new_comment = await comments_collection.insert_one(comment_details)
+    return_comment = await comments_collection.find_one({"_id": new_comment.inserted_id})
+    return comment_helper(return_comment)
+
+
+# Delete the post from comment model
+async def delete_comment(email: str, comment_id: str):
+    user = await users_collection.find_one({"email": email})
+    comment = await comments_collection.find_one({"_id": ObjectId(comment_id)})
+
+    if comment and user["_id"] != comment["user_id"]:
+        raise HTTPException(status_code=403, detail='User not authorized.')
+
+    if comment["is_commented"] is True:
+        updated_post = await comments_collection.update_one(
+            {"_id": ObjectId(comment_id)}, {"$set": {"is_commented": False}}
+        )
+        if updated_post:
+            return True
+        else:
+            return False
+    else:
+        raise HTTPException(status_code=404, detail='Comment does not exist.')

--- a/backend/app/server/database.py
+++ b/backend/app/server/database.py
@@ -9,3 +9,4 @@ database = client.users
 users_collection = database.get_collection("users_collection")
 posts_collection = database.get_collection("posts_collection")
 likes_collection = database.get_collection("likes_collection")
+comments_collection = database.get_collection("comments_collection")

--- a/backend/app/server/models/comment.py
+++ b/backend/app/server/models/comment.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field
+
+
+class CommentSchema(BaseModel):
+    post_id: str = Field(...)
+    user_id: str = Field(None)
+    payload: str = Field(...)
+    is_commented: bool = Field(True)
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "post_id": "<post_id> to comment",
+                "payload": "A nice comment"
+            }
+        }
+
+
+def ResponseModel(data, message):
+    return {
+        "data": [data],
+        "code": 200,
+        "message": message,
+    }
+
+
+def ErrorResponseModel(error, code, message):
+    return {"error": error, "code": code, "message": message}

--- a/backend/app/server/routes/comment.py
+++ b/backend/app/server/routes/comment.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Body, Depends
+from fastapi.encoders import jsonable_encoder
+from ..controllers.auth import auth_handler
+
+from ..controllers.comment import (
+    add_comment,
+    delete_comment
+)
+from ..models.comment import (
+    ResponseModel,
+    CommentSchema,
+)
+
+router = APIRouter()
+
+
+@router.post("/add", response_description="Add a comment to a post")
+async def add_comment_post_data(comment_details: CommentSchema = Body(...), current_user=Depends(auth_handler.auth_wrapper)):
+    comment_details = jsonable_encoder(comment_details)
+    new_comment = await add_comment(current_user, comment_details)
+    return ResponseModel(new_comment, "Comment added successfully.")
+
+
+@router.delete("/delete", response_description="Delete a comment from a post")
+async def delete_comment_post_data(comment_id: str, current_user=Depends(auth_handler.auth_wrapper)):
+    new_comment = await delete_comment(current_user, comment_id)
+    return ResponseModel(new_comment, "Comment deleted successfully.")


### PR DESCRIPTION
Built over the previous PR #37 (merge it before this one)

Now things are starting to come together, requests are now supposed to be tailored to frontend, but _Not correctly_ (will raise an issue about this).
Ultimately we'll have to move Comments and Likes APIs under `/post` prefix.

Resolves #16 
