### PR TITLE
Form values cleared after "Submit"

### DIFF
--- a/frontend/src/Components/Account/Login.js
+++ b/frontend/src/Components/Account/Login.js
@@ -25,7 +25,7 @@ export default function Login({ onToggle }) {
     axios
       .post(LOGIN_URL, { ...form })
       .then((resp) => {
-        setForm(initForm);        
+        setForm(initForm);
         toast.success(JSON.stringify(resp.data.message));
         localStorage.setItem("access_token", resp.data.data.access_token);
         navigate("/home");

--- a/frontend/src/Components/Account/Login.js
+++ b/frontend/src/Components/Account/Login.js
@@ -25,6 +25,7 @@ export default function Login({ onToggle }) {
     axios
       .post(LOGIN_URL, { ...form })
       .then((resp) => {
+        setForm(initForm);        
         toast.success(JSON.stringify(resp.data.message));
         localStorage.setItem("access_token", resp.data.data.access_token);
         navigate("/home");

--- a/frontend/src/Components/Account/Register.js
+++ b/frontend/src/Components/Account/Register.js
@@ -98,6 +98,7 @@ export default function Register({ onToggle }) {
           },
         })
         .then((resp) => {
+          setForm(initForm);
           toast.success(resp.data.message);
           navigate("/home");
           onToggle();

--- a/frontend/src/Components/Navbars/Navbar.js
+++ b/frontend/src/Components/Navbars/Navbar.js
@@ -171,6 +171,7 @@ export default function Navbar({ links, logout }) {
                   key={result.user_id}
                   className="w-full"
                   onClick={() => {
+                    setSearchKey("");
                     navigate(`/user/${result.user_id}`);
                     window.location.reload();
                   }}

--- a/frontend/src/Components/Post/CreatePost.js
+++ b/frontend/src/Components/Post/CreatePost.js
@@ -40,6 +40,7 @@ export default function CreatePost({ handleCreatePost }) {
         },
       })
       .then((res) => {
+        setDescription("");
         setLoading(false);
         toast.success(JSON.stringify(res.data.message));
         handleCreatePost(res.data.data);


### PR DESCRIPTION
The values in forms or input fields in:
Login
Register
Search bar
Add posts
are now all cleared after user clicks on "Submit" or chooses a user profile
closes #109 