### PR TITLE
Drop dependency versions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ python-dotenv==0.15.0
 python-multipart==0.0.5
 cloudinary==1.25.0
 flake8==3.8.4
-numpy==1.20.2
-opencv-python==4.5.1
+numpy==1.19.4
+opencv-python==4.4.0.46
 Pillow==8.2.0
 requests==2.25.1


### PR DESCRIPTION
Dropping down versions was a dire necessity for Windows users and Cloud services.

Resolves https://github.com/MLH-Fellowship/SocioMark/issues/125